### PR TITLE
Ignore lib added by top level build system.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/lib
+/target
+


### PR DESCRIPTION
Also ignore target. Make the output of `git status` look nicer.